### PR TITLE
cl-fetch: update Gerrit client

### DIFF
--- a/cl-fetch/main.go
+++ b/cl-fetch/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -79,7 +80,7 @@ func main() {
 
 	c := gerrit.NewClient("https://go-review.googlesource.com", gerrit.GitCookiesAuth())
 
-	cls, err := c.QueryChanges(query, gerrit.QueryChangesOpt{
+	cls, err := c.QueryChanges(context.Background(), query, gerrit.QueryChangesOpt{
 		Fields: []string{"CURRENT_REVISION", "CURRENT_COMMIT"},
 	})
 	if err != nil {


### PR DESCRIPTION
golang.org/x/build/gerrit takes a context.Context as the first argument for
client queries. Updates this binary to match the new format.