### PR TITLE
greplogs: clean up command UI and fix bugs for dashboard triage

### DIFF
--- a/greplogs/flags.go
+++ b/greplogs/flags.go
@@ -42,6 +42,15 @@ func (x *regexpList) AllMatch(data []byte) bool {
 	return true
 }
 
+func (x *regexpList) AnyMatchString(data string) bool {
+	for _, r := range *x {
+		if r.MatchString(data) {
+			return true
+		}
+	}
+	return false
+}
+
 func (x *regexpList) Matches(data []byte) [][]int {
 	matches := [][]int{}
 	for _, r := range *x {

--- a/internal/loganal/failure.go
+++ b/internal/loganal/failure.go
@@ -84,6 +84,11 @@ var (
 	// strip that from the beginning of the line.
 	failPkg = `(?m:^(?:exitcode=1)?FAIL[ \t]+(\S+))`
 
+	// logTruncated matches the "log truncated" line injected by the coordinator.
+	logTruncated = `(?:\n\.\.\. log truncated \.\.\.)`
+
+	endOfTest = `(?:` + failPkg + `|` + logTruncated + `)`
+
 	canonLine = regexp.MustCompile(`\r+\n`)
 
 	// testingHeader matches the beginning of the go test std
@@ -98,7 +103,7 @@ var (
 	// T.Error or a recovered panic. There was a time when the
 	// test name included GOMAXPROCS (like how benchmark names
 	// do), so we strip that out.
-	testingFailed = regexp.MustCompile(`^--- FAIL: ([^-\s]+).*\n(` + linesStar + `)` + failPkg)
+	testingFailed = regexp.MustCompile(`^--- FAIL: ([^-\s]+).*\n(` + linesStar + `)` + endOfTest)
 
 	// testingError matches the file name and message of the last
 	// T.Error in a testingFailed log.
@@ -109,16 +114,16 @@ var (
 	testingPanic = regexp.MustCompile(`panic: (.*?)(?: \[recovered\])`)
 
 	// gotestFailed matches a $GOROOT/test failure.
-	gotestFailed = regexp.MustCompile(`^# go run run\.go.*\n(` + linesPlus + `)` + failPkg)
+	gotestFailed = regexp.MustCompile(`^# go run run\.go.*\n(` + linesPlus + `)` + endOfTest)
 
 	// buildFailed matches build failures from the testing package.
 	buildFailed = regexp.MustCompile(`^` + failPkg + `\s+\[build failed\]`)
 
 	// timeoutPanic1 matches a test timeout detected by the testing package.
-	timeoutPanic1 = regexp.MustCompile(`^panic: test timed out after .*\n(` + linesStar + `)` + failPkg)
+	timeoutPanic1 = regexp.MustCompile(`^panic: test timed out after .*\n(` + linesStar + `)` + endOfTest)
 
 	// timeoutPanic2 matches a test timeout detected by go test.
-	timeoutPanic2 = regexp.MustCompile(`^\*\*\* Test killed.*ran too long\n` + failPkg)
+	timeoutPanic2 = regexp.MustCompile(`^\*\*\* Test killed.*ran too long\n` + endOfTest)
 
 	// coordinatorTimeout matches a test timeout detected by the
 	// coordinator, for both non-sharded and sharded tests.
@@ -138,7 +143,7 @@ var (
 	// throw.
 	runtimeFailed        = regexp.MustCompile(`^(?:runtime:.*\n)*.*(?:panic: |fatal error: )(.*)`)
 	runtimeLiterals      = []string{"runtime:", "panic:", "fatal error:"}
-	runtimeFailedTrailer = regexp.MustCompile(`^(?:exit status.*\n)?(?:\*\*\* Test killed.*\n)?(?:` + failPkg + `)?`)
+	runtimeFailedTrailer = regexp.MustCompile(`^(?:exit status.*\n)?(?:\*\*\* Test killed.*\n)?` + endOfTest + `?`)
 
 	// apiCheckerFailed matches an API checker failure.
 	apiCheckerFailed = regexp.MustCompile(`^Error running API checker: (.*)`)
@@ -149,7 +154,7 @@ var (
 
 	// testingUnknownFailed matches the last line of some unknown
 	// failure detected by the testing package.
-	testingUnknownFailed = regexp.MustCompile(`^` + failPkg)
+	testingUnknownFailed = regexp.MustCompile(`^` + endOfTest)
 
 	// miscFailed matches the log.Fatalf in go tool dist test when
 	// a test fails. We use this as a last resort, mostly to pick

--- a/internal/loganal/failure.go
+++ b/internal/loganal/failure.go
@@ -133,7 +133,9 @@ var (
 	// function/line number entry in a traceback. Group 1 matches
 	// the fully qualified function name. Groups 2 and 3 match the
 	// file name and line number.
-	tbEntry = `(\S+)\(.*\)\n\t(.*):([0-9]+) .*\n`
+	// Most entries have trailing stack metadata for each frame,
+	// but inlined calls, lacking a frame, may omit that metadata.
+	tbEntry = `(\S+)\(.*\)\n\t(.*):([0-9]+)(?: .*)?\n`
 
 	// runtimeFailed matches a runtime throw or testing package
 	// panic. Matching the panic is fairly loose because in some


### PR DESCRIPTION
This is my current stack of fixes for `greplogs` hangs and CLI additions for daily builder triage.

I use the `-omit` flag to filter out known-bad builders, and the `--before` flag to bracket failures by timestamp to avoid double-counting.